### PR TITLE
Use raw_input rather than input.

### DIFF
--- a/MemeDensity/command_line.py
+++ b/MemeDensity/command_line.py
@@ -29,7 +29,7 @@ from argparse import RawTextHelpFormatter
 
 def _login_fb():
 
-	email = input('> Email or Phone: ')
+	email = raw_input('> Email or Phone: ')
 	password = getpass('> Password: ')
 
 	return email,password


### PR DESCRIPTION
This tweak lets you enter your email address without having to do a quoted literal.

> Email or Phone: mental@neverlight.com
> Password:

Loading..

Using input() means you're actually calling eval() on whatever raw_input() returns. Which will blow up on the @ sign in an email address. I'm also not sure why you'd want to eval() a phone number.

Prior to this you'd need to do 
> Email or Phone: 'mental@neverlight.com'


FWIW you're also mixing tabs and spaces in your indentation levels. It makes the code janky to read.