### PR TITLE
Use raw_input on Python 2

### DIFF
--- a/MemeDensity/command_line.py
+++ b/MemeDensity/command_line.py
@@ -20,12 +20,17 @@ newsfeed. Provides % memes in newsfeed.
 import os
 import argparse
 import requests
+import six
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 from time import sleep
 from getpass import getpass
 from argparse import RawTextHelpFormatter
 
+if six.PY2:
+	input = raw_input
+else:
+	pass
 
 def _login_fb():
 


### PR DESCRIPTION
In Python 2, the input function interprets the read text as Python
code, so you have to quote your email address when typing it in.
This tries to do it the Python 2 way, and if that fails (i.e. raw_input
isn't defined), then the Python 3 way.